### PR TITLE
Require cabal-version 1.8

### DIFF
--- a/flexible-defaults.cabal
+++ b/flexible-defaults.cabal
@@ -2,7 +2,7 @@ name:                   flexible-defaults
 version:                0.0.3
 stability:              provisional
 
-cabal-version:          >= 1.6
+cabal-version:          >= 1.8
 build-type:             Simple
 
 author:                 James Cook <mokus@deepbondi.net>


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: flexible-defaults.cabal:47:37: version operators used. To use version
operators the package needs to specify at least 'cabal-version: >= 1.8'.
```